### PR TITLE
API: Json-rpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
     - platform-tools
     - tools
     - android-25
-    - build-tools-25.0.3
+    - build-tools-26.0.2
     - extra-android-m2repository
 
 branches:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,18 +3,21 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
+apply plugin: 'com.getkeepsafe.dexcount'
 
 android {
     // we use 25 sdk because advRecyclerView doesn't support 26 sdk yet
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId 'me.myshows.android'
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
         versionName '1.0'
+
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -57,6 +60,9 @@ dependencies {
     implementation (libraries.advRecyclerView) { transitive = true }
     implementation libraries.circleImageView
     implementation libraries.circleIndicator
+
+    implementation libraries.jackson
+    implementation libraries.jacksonKotlin
 
     implementation libraries.okhttp
     implementation libraries.okhttpLogging

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,22 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
+    }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                events 'passed', 'skipped', 'failed'
+                exceptionFormat = 'full'
+            }
+            afterSuite { desc, result ->
+                if (!desc.parent) {
+                    def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                    println("\n$output\n")
+                }
+            }
+        }
     }
 }
 
@@ -87,4 +103,8 @@ dependencies {
 
     debugImplementation libraries.leakCanary
     releaseImplementation libraries.leakCanaryNoOp
+
+    testImplementation libraries.junit
+    testImplementation libraries.assertj
+    testImplementation libraries.mockwebserver
 }

--- a/app/src/main/kotlin/me/myshows/android/api/jsonrpc/JsonRPCConverterFactory.kt
+++ b/app/src/main/kotlin/me/myshows/android/api/jsonrpc/JsonRPCConverterFactory.kt
@@ -1,0 +1,69 @@
+package me.myshows.android.api.jsonrpc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectReader
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Converter
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+
+class JsonRPCConverterFactory private constructor(private val mapper: ObjectMapper) : Converter.Factory() {
+
+    override fun responseBodyConverter(type: Type, annotations: Array<Annotation>,
+                                       retrofit: Retrofit): Converter<ResponseBody, *>? {
+        if (annotations.none { it is JsonRPCMethod }) return null
+
+        val returnType = mapper.typeFactory.constructType(type)
+        if (!returnType.hasRawClass(Result::class.java)) return null
+        val resultType = returnType.bindings.getBoundType(0) ?: return null
+        val errorType = returnType.bindings.getBoundType(1) ?: return null
+        if (!errorType.hasRawClass(Error::class.java)) return null
+
+        val javaType = mapper.typeFactory.constructParametricType(JsonRPCResponseObject::class.java, resultType)
+        val reader = mapper.readerFor(javaType)
+        return JsonRPCResponseBodyConverter<Any>(reader)
+    }
+
+    override fun requestBodyConverter(type: Type, parameterAnnotations: Array<out Annotation>,
+                                      methodAnnotations: Array<out Annotation>, retrofit: Retrofit): Converter<*, RequestBody>? {
+        val methodAnnotation = methodAnnotations.find { it is JsonRPCMethod } as? JsonRPCMethod ?: return null
+        return JsonRPCRequestBodyConverter<Any>(mapper, methodAnnotation.method)
+    }
+
+    companion object {
+        @JvmStatic
+        fun create(objectMapper: ObjectMapper = jacksonObjectMapper()): JsonRPCConverterFactory =
+                JsonRPCConverterFactory(objectMapper)
+    }
+}
+
+private class JsonRPCRequestBodyConverter<T>(
+        private val mapper: ObjectMapper,
+        private val method: String
+) : Converter<T, RequestBody> {
+
+    override fun convert(value: T): RequestBody {
+        val requestObject = JsonRPCRequestObject(method, value)
+        val bytes = mapper.writeValueAsBytes(requestObject)
+        return RequestBody.create(MEDIA_TYPE, bytes)
+    }
+
+    companion object {
+        private val MEDIA_TYPE = MediaType.parse("application/json; charset=UTF-8")
+    }
+}
+
+private class JsonRPCResponseBodyConverter<T>(private val reader: ObjectReader) : Converter<ResponseBody, JsonRPCResult<T>> {
+
+    override fun convert(value: ResponseBody): JsonRPCResult<T> {
+        val responseObject = value.use { reader.readValue<JsonRPCResponseObject<T>>(it.charStream()) }
+        return when {
+            responseObject.result != null -> Ok(responseObject.result)
+            responseObject.error != null -> Err(responseObject.error)
+            else -> error("Unreachable")
+        }
+    }
+}

--- a/app/src/main/kotlin/me/myshows/android/api/jsonrpc/JsonRPCMethod.kt
+++ b/app/src/main/kotlin/me/myshows/android/api/jsonrpc/JsonRPCMethod.kt
@@ -1,0 +1,4 @@
+package me.myshows.android.api.jsonrpc
+
+@Target(AnnotationTarget.FUNCTION)
+annotation class JsonRPCMethod(val method: String)

--- a/app/src/main/kotlin/me/myshows/android/api/jsonrpc/JsonRPCObjects.kt
+++ b/app/src/main/kotlin/me/myshows/android/api/jsonrpc/JsonRPCObjects.kt
@@ -1,0 +1,31 @@
+package me.myshows.android.api.jsonrpc
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+const val JSON_RPC_VERSION: String = "2.0"
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class JsonRPCRequestObject<out T>(
+        @JsonProperty("method") val method: String,
+        @JsonProperty("param") val param: T,
+        @JsonProperty("jsonrpc") val jsonrpc: String = JSON_RPC_VERSION,
+        @JsonProperty("id") val id: Int = 1
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class JsonRPCResponseObject<out T>(
+        @JsonProperty("result") val result: T?,
+        @JsonProperty("error") val error: Error? = null,
+        @JsonProperty("jsonrpc") val jsonrpc: String = JSON_RPC_VERSION,
+        @JsonProperty("id") val id: Int = 1
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Error(
+    @JsonProperty("code") val code: Int,
+    @JsonProperty("message") val message: String,
+    @JsonProperty("data") val data: Any?
+)
+
+typealias JsonRPCResult<T> = Result<T, Error>

--- a/app/src/main/kotlin/me/myshows/android/api/jsonrpc/Result.kt
+++ b/app/src/main/kotlin/me/myshows/android/api/jsonrpc/Result.kt
@@ -1,0 +1,6 @@
+package me.myshows.android.api.jsonrpc
+
+sealed class Result<out T, out E>
+
+data class Ok<out T>(val value: T) : Result<T, Nothing>()
+data class Err<out E>(val error: E) : Result<Nothing, E>()

--- a/app/src/test/kotlin/me/myshows/android/api/BaseMockWebServerTest.kt
+++ b/app/src/test/kotlin/me/myshows/android/api/BaseMockWebServerTest.kt
@@ -1,0 +1,30 @@
+package me.myshows.android.api
+
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Before
+import java.net.HttpURLConnection
+
+abstract class BaseMockWebServerTest {
+
+    protected val server: MockWebServer = MockWebServer().apply {
+        setDispatcher(object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = response(request)
+        })
+    }
+
+    @Before
+    fun start() = server.start()
+
+    @After
+    fun stop() = server.shutdown()
+
+    protected fun resolve(path: String): String = server.url(path).toString()
+    protected fun notFound(): MockResponse = MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+
+    @Throws(InterruptedException::class)
+    protected abstract fun response(request: RecordedRequest): MockResponse
+}

--- a/app/src/test/kotlin/me/myshows/android/api/jsonrpc/JsonRPCTest.kt
+++ b/app/src/test/kotlin/me/myshows/android/api/jsonrpc/JsonRPCTest.kt
@@ -1,0 +1,109 @@
+package me.myshows.android.api.jsonrpc
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import me.myshows.android.api.BaseMockWebServerTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.POST
+import java.net.HttpURLConnection
+
+class JsonRPCTest : BaseMockWebServerTest() {
+
+    private val mapper: ObjectMapper = jacksonObjectMapper()
+    private lateinit var api: TestApi
+
+    @Before
+    fun setup() {
+        api = Retrofit.Builder()
+                .addConverterFactory(JsonRPCConverterFactory.create())
+                .baseUrl(resolve("/"))
+                .build()
+                .create(TestApi::class.java)
+    }
+
+    @Test
+    fun correctJsonRpcMethod() {
+        val value = "foo"
+        val response = api.method1(Request(value)).execute()
+        assertThat(response.code()).isEqualTo(HttpURLConnection.HTTP_OK)
+        assertThat(response.body())
+                .isNotNull()
+                .isInstanceOf(Ok::class.java)
+        assertThat((response.body() as Ok).value.result).isEqualTo(value)
+    }
+
+    @Test
+    fun unknownJsonRpcMethod() {
+        val value = "foo"
+        val response = api.method2(Request(value)).execute()
+        assertThat(response.code()).isEqualTo(HttpURLConnection.HTTP_OK)
+        assertThat(response.body())
+                .isNotNull()
+                .isInstanceOf(Err::class.java)
+    }
+
+    @Test(expected = Exception::class)
+    fun incorrectJsonRpcMethod() {
+        api.method3(Request("foo")).execute()
+    }
+
+    @Test(expected = Exception::class)
+    fun wrongReturnType() {
+        api.method3(Request("foo")).execute()
+    }
+
+    override fun response(request: RecordedRequest): MockResponse = when (request.path) {
+        "/rpc" -> {
+            val requestObject = request.body.into<JsonRPCRequestObject<Request>>()
+            val responseObject = if (requestObject.method == METHOD_NAME) {
+                JsonRPCResponseObject(Response(requestObject.param.value))
+            } else {
+                JsonRPCResponseObject(null, Error(400, "Method not found", null))
+            }
+
+            MockResponse()
+                    .setResponseCode(HttpURLConnection.HTTP_OK)
+                    .addHeader("Content-Type", "application/json; charset=UTF-8")
+                    .setBody(mapper.writeValueAsString(responseObject))
+        }
+        else -> notFound()
+    }
+
+    private inline fun <reified T: Any> Buffer.into(): T = mapper.readValue(inputStream())
+
+    companion object {
+        private const val METHOD_NAME: String = "test.method"
+        private const val UNKNOWN_METHOD_NAME: String = "test.unwnown-method"
+    }
+
+    data class Request(@JsonProperty("value") val value: String)
+    data class Response(@JsonProperty("result") val result: String)
+
+    interface TestApi {
+
+        @JsonRPCMethod(METHOD_NAME)
+        @POST("/rpc")
+        fun method1(@Body request: Request): Call<JsonRPCResult<Response>>
+
+        @JsonRPCMethod(UNKNOWN_METHOD_NAME)
+        @POST("/rpc")
+        fun method2(@Body request: Request): Call<JsonRPCResult<Response>>
+
+        @POST("/rpc")
+        fun method3(@Body request: Request): Call<JsonRPCResult<Response>>
+
+        @JsonRPCMethod(METHOD_NAME)
+        @POST("/rpc")
+        fun method4(@Body request: Request): Call<Response>
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,10 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:' + kotlinVersion
         classpath 'io.realm:realm-gradle-plugin:3.7.2'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.1'
     }
 }
 
@@ -27,7 +28,8 @@ def versions = [
         glide           : '4.1.1',
         parceler        : '1.1.9',
         rxLifecycle     : '0.4.0',
-        leakCanary      : '1.5.4'
+        leakCanary      : '1.5.4',
+        jackson         : '2.9.1'
 ]
 
 ext.libraries = [
@@ -48,6 +50,10 @@ ext.libraries = [
         circleImageView               : 'de.hdodenhof:circleimageview:2.1.0',
         circleIndicator               : 'me.relex:circleindicator:1.1.8@aar',
 
+        // jackson libraries
+        jackson                       : 'com.fasterxml.jackson.core:jackson-databind:' + versions.jackson,
+        jacksonKotlin                 : 'com.fasterxml.jackson.module:jackson-module-kotlin:' + versions.jackson,
+
         // internet libraries
         okhttp                        : 'com.squareup.okhttp3:okhttp:' + versions.okhttp,
         okhttpLogging                 : 'com.squareup.okhttp3:logging-interceptor:' + versions.okhttp,
@@ -58,7 +64,6 @@ ext.libraries = [
         glide                         : 'com.github.bumptech.glide:glide:' + versions.glide,
         glideCompiler                 : 'com.github.bumptech.glide:compiler:' + versions.glide,
         glideOkhttp                   : 'com.github.bumptech.glide:okhttp3-integration:' + versions.glide,
-
 
         // rx libraries
         rxJava                        : 'io.reactivex:rxjava:1.1.1',

--- a/build.gradle
+++ b/build.gradle
@@ -79,5 +79,10 @@ ext.libraries = [
         commonsIO                     : 'commons-io:commons-io:2.4',
 
         leakCanary                    : 'com.squareup.leakcanary:leakcanary-android:' + versions.leakCanary,
-        leakCanaryNoOp                : 'com.squareup.leakcanary:leakcanary-android-no-op:' + versions.leakCanary
+        leakCanaryNoOp                : 'com.squareup.leakcanary:leakcanary-android-no-op:' + versions.leakCanary,
+
+        // test libraries
+        junit                         : 'junit:junit:4.12',
+        mockwebserver                 : 'com.squareup.okhttp3:mockwebserver:' + versions.okhttp,
+        assertj                       : 'org.assertj:assertj-core:2.8.0'
 ]


### PR DESCRIPTION
Introduce `JsonRPCConverterFactory`! It will simplify future implementation of myshows api.

Common json objects we communicate with api is something like this:
**request**:
```
{
  "jsonrpc": "2.0",
  "method": "method.name",
  "param": some-json-object,
  "id": some-integer
}
```
**response**:
```
{
  "jsonrpc": "2.0",
  "result": some-json-object,
  "id": some-integer
}
```
or
```
{
  "jsonrpc": "2.0",
  "error": {
    "code": some-integer,
    "message": "some-message",
    "data": some-json-object
  },
  "id": some-integer
}
```
We are really interested only in `param` and `result`/`error` objects and want to pass method name.
Now we can create api interface in following way:
```kotlin
interface Api {
    @JsonRPCMethod("method-name")
    @POST("some-path")
    fun method(@Body param: ParamObject): Call<JsonRPCResult<ResultObject>>
}
```